### PR TITLE
pull enums.py file for minor magic string edits

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,18 +6,20 @@
 Main Flask backend control file for Codelet.
 """
 
-from cs50 import SQL  # contains SQL setup
-from datetime import datetime, timedelta
-from flask import Flask, render_template, redirect, request, Response as flaskResponse, session
-from flask_session import Session  # store session data on server side
 import json
 import pytz  # timezone functionality
 import re
 import sqlite3
+
+from cs50 import SQL  # contains SQL setup
+from datetime import datetime, timedelta
+from flask import Flask, render_template, redirect, request, Response as flaskResponse, session
+from flask_session import Session  # store session data on server side
 from werkzeug import Response as werkzeugResponse
 from werkzeug.security import check_password_hash, generate_password_hash
 
 import helpers
+from enums import HtmlPageName, RequestMethod, UrlExt
 
 # Configure Flask application in current file in debug mode.
 app = Flask(__name__)
@@ -91,7 +93,7 @@ def after_request(response: flaskResponse) -> flaskResponse:
     return response
 
 
-@app.route("/")
+@app.route(UrlExt.INDEX)
 @helpers.login_required
 def index() -> str:
     """Show user's sets."""
@@ -146,22 +148,22 @@ def index() -> str:
             past_ever_sets.append(set)
 
     # Render index with relevant variables for Jinja templating.
-    return render_template("index.html",
+    return render_template(HtmlPageName.INDEX,
                            user_username=user_username,
                            past_day_sets=past_day_sets,
                            past_week_sets=past_week_sets,
                            past_month_sets=past_month_sets,
                            past_ever_sets=past_ever_sets
-                          )
+                           )
 
 
-@app.route("/create", methods=["GET", "POST"])
+@app.route(UrlExt.CREATE, methods=[RequestMethod.GET, RequestMethod.POST])
 @helpers.login_required
 def create() -> tuple[str, int] | werkzeugResponse | str:
     """Create flashcards."""
 
     # If user arrived to /create via POST,
-    if request.method == "POST":
+    if request.method == RequestMethod.POST:
         # Verify that form has input.
         if not request.form:
             return helpers.apology("Empty submission.")
@@ -178,7 +180,7 @@ def create() -> tuple[str, int] | werkzeugResponse | str:
 
                 # Save the term.
                 if number not in flashcards:
-                    flashcards[number]= {"term": html_value}
+                    flashcards[number] = {"term": html_value}
                 else:
                     flashcards[number]["term"] = html_value
             # If not, do the same for "definition".
@@ -188,7 +190,7 @@ def create() -> tuple[str, int] | werkzeugResponse | str:
 
                 # Save the definition.
                 if number not in flashcards:
-                    flashcards[number]= {"definition": html_value}
+                    flashcards[number] = {"definition": html_value}
                 else:
                     flashcards[number]["definition"] = html_value
 
@@ -237,16 +239,16 @@ def create() -> tuple[str, int] | werkzeugResponse | str:
 
     # If user arrived to /create via GET, render page.
     else:
-        return render_template("create.html")
+        return render_template(HtmlPageName.CREATE)
 
 
-@app.route("/edit/<int:set_id>", methods=["GET", "POST"])
+@app.route("/edit/<int:set_id>", methods=[RequestMethod.GET, RequestMethod.POST])
 @helpers.login_required
 def edit(set_id: int) -> tuple[str, int] | werkzeugResponse | str:
     """Edit flashcards."""
 
     # If user arrived to /edit via POST,
-    if request.method == "POST":
+    if request.method == RequestMethod.POST:
         # Verify that form has input.
         if not request.form:
             return helpers.apology("Empty submission.")
@@ -288,7 +290,7 @@ def edit(set_id: int) -> tuple[str, int] | werkzeugResponse | str:
 
                     # Save the term.
                     if html_number not in new_flashcards:
-                        new_flashcards[html_number]= {"term": html_value}
+                        new_flashcards[html_number] = {"term": html_value}
                     else:
                         new_flashcards[html_number]["term"] = html_value
 
@@ -299,7 +301,7 @@ def edit(set_id: int) -> tuple[str, int] | werkzeugResponse | str:
 
                     # Save the definition.
                     if html_number not in new_flashcards:
-                        new_flashcards[html_number]= {"definition": html_value}
+                        new_flashcards[html_number] = {"definition": html_value}
                     else:
                         new_flashcards[html_number]["definition"] = html_value
 
@@ -430,10 +432,11 @@ def edit(set_id: int) -> tuple[str, int] | werkzeugResponse | str:
             set_id
         )
 
-        return render_template("edit.html", flashcard_data=flashcard_data,
-                                set_data=set_data)
+        return render_template(HtmlPageName.EDIT, flashcard_data=flashcard_data,
+                               set_data=set_data)
 
-@app.route("/login", methods=["GET", "POST"])
+
+@app.route(UrlExt.LOGIN, methods=[RequestMethod.GET, RequestMethod.POST])
 def login() -> tuple[str, int] | werkzeugResponse | str:
     """Log user in."""
 
@@ -441,7 +444,7 @@ def login() -> tuple[str, int] | werkzeugResponse | str:
     session.clear()
 
     # If user reached login route via POST (e.g. submitting a POST form)
-    if request.method == "POST":
+    if request.method == RequestMethod.POST:
         # Ensure username was submitted.
         form_username = request.form.get("username")
         if not form_username:
@@ -474,10 +477,10 @@ def login() -> tuple[str, int] | werkzeugResponse | str:
 
     # If user reached login route via GET (e.g. clicking link; redirect)
     else:
-        return render_template("login.html")
+        return render_template(HtmlPageName.LOGIN)
 
 
-@app.route("/logout")
+@app.route(UrlExt.LOGOUT)
 def logout() -> werkzeugResponse | str:
     """Log user out."""
 
@@ -488,12 +491,12 @@ def logout() -> werkzeugResponse | str:
     return redirect("/")
 
 
-@app.route("/register", methods=["GET", "POST"])
+@app.route(UrlExt.REGISTER, methods=[RequestMethod.GET, RequestMethod.POST])
 def register() -> tuple[str, int] | werkzeugResponse | str:
     """Register user into codelet.db database via a form."""
 
     # If user navs to /register via POST (e.g. through form submission)
-    if request.method == "POST":
+    if request.method == RequestMethod.POST:
         # Retrieve user data from database.
         users = db.execute("SELECT * FROM users")
 
@@ -510,8 +513,8 @@ def register() -> tuple[str, int] | werkzeugResponse | str:
 
         # Apologize if username has forbidden characters or length.
         if (
-            re.search("[^a-zA-Z0-9_-]", form_username)
-            or not 3 <= len(form_username) <= 16
+                re.search("[^a-zA-Z0-9_-]", form_username)
+                or not 3 <= len(form_username) <= 16
         ):
             return helpers.apology(
                 "Username must only contain alphanumeric characters/"
@@ -624,10 +627,10 @@ def register() -> tuple[str, int] | werkzeugResponse | str:
 
     # Render page if user did not arrive via POST.
     else:
-        return render_template("register.html")
+        return render_template(HtmlPageName.REGISTER)
 
 
-@app.route("/set/<int:set_id>", methods=["GET", "POST"])
+@app.route("/set/<int:set_id>", methods=[RequestMethod.GET, RequestMethod.POST])
 @helpers.login_required
 def set(set_id: int) -> tuple[str, int] | werkzeugResponse | str:
     """Display specific set with unique id."""
@@ -673,5 +676,5 @@ def set(set_id: int) -> tuple[str, int] | werkzeugResponse | str:
         set_id
     )
 
-    return render_template("set.html", flashcard_data=flashcard_data,
+    return render_template(HtmlPageName.SET, flashcard_data=flashcard_data,
                            set_data=set_data)

--- a/enums.py
+++ b/enums.py
@@ -1,0 +1,64 @@
+"""
+Constant page name definitions for Codelet (not necessarily "enum" 
+types, but similar intent).
+"""
+
+
+class HtmlPageName:
+    """HTML filenames to help render pages."""
+
+    # View all sets of cards for the user.
+    INDEX: str = "index.html"
+
+    # Create a set of cards.
+    CREATE: str = "create.html"
+
+    # Edit a set of cards.
+    EDIT: str = "edit.html"
+
+    # Login to a user account.
+    LOGIN: str = "login.html"
+
+    # Register a new account.
+    REGISTER: str = "register.html"
+
+    # View a set of cards.
+    SET: str = "set.html"
+
+    # Display an error.
+    APOLOGY: str = "apology.html"
+
+
+class RequestMethod:
+    """HTTP request types to check flask.request."""
+
+    GET: str = "GET"
+    POST: str = "POST"
+
+
+class UrlExt:
+    """URL extensions for each page, used in @app.route()."""
+    
+    # View all sets of cards for the user.
+    INDEX: str = "/"
+
+    # Create a set of cards.
+    CREATE: str = "/create"
+
+    # Edit a set of cards. TODO: "/edit/<int:set_id>"
+    EDIT: str = "/edit"
+
+    # Login to a user account.
+    LOGIN: str = "/login"
+
+    # Logout confirmation.
+    LOGOUT: str = "/logout"
+
+    # Register a new account.
+    REGISTER: str = "/register"
+
+    # View a set of cards. TODO: "/set/<int:set_id>"
+    SET: str = "/set"
+
+    # Display an error.
+    APOLOGY: str = "/apology"

--- a/helpers.py
+++ b/helpers.py
@@ -10,6 +10,8 @@ import uuid
 from flask import redirect, render_template, session
 from functools import wraps
 
+import enums
+
 
 def apology(message: str, code: int = 400) -> tuple[str, int] | str:
     """Render message as an apology to the user."""
@@ -33,7 +35,7 @@ def apology(message: str, code: int = 400) -> tuple[str, int] | str:
             s = s.replace(old, new)
         return s
 
-    return render_template("apology.html", top=code, bottom=escape(message)), code
+    return render_template(PageName.APOLOGY, top=code, bottom=escape(message)), code
 
 
 def login_required(f: Callable) -> Callable:


### PR DESCRIPTION
The original implementations for app.y and helpers.py have a lot of magic strings, so an "enums.py" file was created to provide a centralized single-definition structure using classes in an enum-style way (albeit not with explicit "Enum" types).

New classes so far include HtmlPageName ("index.html", etc.), RequestMethod ("GET", "POST"), and UrlExt ("/", "/create", etc.).